### PR TITLE
Prod changes, active subjects and count volunteers in chat

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -18,11 +18,10 @@ services:
         ports:
             - "8000:8000"
     server:
-        build: 
+        build:
             context: server/
             dockerfile: Dockerfile
         image: redcross-backend
         ports:
             - "8080:8080"
-            - "3002:3002"
 

--- a/Docker/server/Dockerfile
+++ b/Docker/server/Dockerfile
@@ -28,7 +28,6 @@ RUN chmod 755 $HOME/*.sh && \
 
 ## Expose application port
 EXPOSE 8080
-EXPOSE 3002
 
 USER $USER
 WORKDIR /home/$USER

--- a/Docker/server/runapp.sh
+++ b/Docker/server/runapp.sh
@@ -10,6 +10,7 @@ set -x
 # If AZURE_KEYVAULT_ENABLED equals "true"
 # The properties with path $AZURE_KEYVAULT_PATH will be written to $AZURE_KEYVAULT_OUTPUTPATH
 # The path is stripped to the output. eg /dev/myapp/db.password=1234 is added to the file as db.password=1234.
+echo $AZURE_KEYVAULT_ENABLED
 if [ "$AZURE_KEYVAULT_ENABLED" = "true" ]; then
     touch $AZURE_KEYVAULT_OUTPUTPATH
     if python3 GetSecretsFromKeyVault.py $AZURE_KEYVAULT_PATH $AZURE_KEYVAULT_OUTPUTPATH; then

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
       <artifactId>jaxb-api</artifactId>
       <version>2.2.11</version>
     </dependency>
+    <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>adal4j</artifactId>
+      <version>1.6.0</version>
+    </dependency>
     <!-- We need this because reasons -->
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,11 @@
     </dependency>
     <!-- Mail -->
     <dependency>
+      <groupId>com.sendgrid</groupId>
+      <artifactId>sendgrid-java</artifactId>
+      <version>4.4.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-email</artifactId>
       <version>1.5</version>

--- a/src/main/java/no/capraconsulting/AppMain.java
+++ b/src/main/java/no/capraconsulting/AppMain.java
@@ -1,6 +1,7 @@
 package no.capraconsulting;
 
 import no.capraconsulting.chat.ChatServer;
+import no.capraconsulting.chat.ChatServlet;
 import no.capraconsulting.config.JerseyConfig;
 import no.capraconsulting.config.JsonJettyErrorHandler;
 import no.capraconsulting.config.PropertiesHelper;
@@ -57,8 +58,8 @@ public class AppMain {
         // Add Jersey servlet to the Jetty context
         ServletHolder jerseyServlet = new ServletHolder(new ServletContainer(new JerseyConfig(properties)));
         contextHandler.addServlet(jerseyServlet, "/*");
-        //contextHandler.addServlet(ChatEndpoint.class.getName(), "/ws");
-
+        ServletHolder chatServlet = new ServletHolder("ws-events", ChatServlet.class);
+        contextHandler.addServlet(chatServlet, "/ws");
         // Error responses as application/json with proper charset
         contextHandler.setErrorHandler(new JsonJettyErrorHandler());
 

--- a/src/main/java/no/capraconsulting/chat/ChatEndpoint.java
+++ b/src/main/java/no/capraconsulting/chat/ChatEndpoint.java
@@ -36,7 +36,7 @@ public class ChatEndpoint extends WebSocketAdapter {
     // <uniqueID, ClosedChat>
     static final ConcurrentMap<String, ClosedChat> reconnectList = new ConcurrentHashMap<>();
 
-    static final ConcurrentMap<String, Volunteer> activeVolunteers = new ConcurrentHashMap<>();
+    public static final ConcurrentMap<String, Volunteer> activeVolunteers = new ConcurrentHashMap<>();
 
     // <uniqueID, Long> TODO: Sandra, et ConcurrentMap som holder på studentID og når student entret chat. Må tømmes når får timeout når leksehjelp er stengt, og student må fjernes når chat med student lukkes.
     static final ConcurrentMap<String, Long> studentsEnteredChat = new ConcurrentHashMap<>();
@@ -82,7 +82,8 @@ public class ChatEndpoint extends WebSocketAdapter {
                 generateRoomMessageHandler(payload);
                 break;
             case QUEUE_LIST:
-                getQueue();
+                SocketMessage queueMessage = getQueueMessage();
+                this.sendClient(ChatUtils.stringify(queueMessage));
                 break;
             case JOIN_CHAT:
                 addToChat(payload);
@@ -142,10 +143,10 @@ public class ChatEndpoint extends WebSocketAdapter {
         ChatEndpoint.sockets.put(this.id, this);
 
         SocketMessage msg =
-                SocketMessage.Builder.newInstance()
-                        .withMsgType(Msg.MessageEnum.CONNECTION)
-                        .withPayload(new Message.Builder().withUniqueID(this.id).build())
-                        .build();
+            SocketMessage.Builder.newInstance()
+                .withMsgType(Msg.MessageEnum.CONNECTION)
+                .withPayload(new Message.Builder().withUniqueID(this.id).build())
+                .build();
 
         this.sendClient(ChatUtils.stringify(msg));
         LOG.info("New client connected");
@@ -154,20 +155,20 @@ public class ChatEndpoint extends WebSocketAdapter {
 
     static void updatePositionsInQueue() {
         ChatEndpoint.waitingRooms.forEach(
-                (uid, si) -> {
-                    si.decrementPositionInQueue();
-                    StudentInfoMessage updateMessage =
-                            new StudentInfoMessage.Builder().withStudentInfo(si).build();
+            (uid, si) -> {
+                si.decrementPositionInQueue();
+                StudentInfoMessage updateMessage =
+                    new StudentInfoMessage.Builder().withStudentInfo(si).build();
 
-                    ChatEndpoint.sockets
-                            .get(uid)
-                            .sendClient(
-                                    ChatUtils.stringify(
-                                            SocketMessage.Builder.newInstance()
-                                                    .withMsgType(Msg.MessageEnum.UPDATE_QUEUE)
-                                                    .withPayload(updateMessage)
-                                                    .build()));
-                });
+                ChatEndpoint.sockets
+                    .get(uid)
+                    .sendClient(
+                        ChatUtils.stringify(
+                            SocketMessage.Builder.newInstance()
+                                .withMsgType(Msg.MessageEnum.UPDATE_QUEUE)
+                                .withPayload(updateMessage)
+                                .build()));
+            });
     }
 
     private void activeVolunteer(String msg) {
@@ -182,17 +183,17 @@ public class ChatEndpoint extends WebSocketAdapter {
         TextMessage partialTextMessage = gson.fromJson(msg, TextMessage.class);
 
         TextMessage textMessage =
-                new TextMessage.Builder()
-                        .withFiles(partialTextMessage.getFiles())
-                        .withAuthor(partialTextMessage.getAuthor())
-                        .withMessage(partialTextMessage.getMessage())
-                        .withUniqueID(partialTextMessage.getUniqueID())
-                        .withRoomID(partialTextMessage.getRoomID())
-                        .build();
+            new TextMessage.Builder()
+                .withFiles(partialTextMessage.getFiles())
+                .withAuthor(partialTextMessage.getAuthor())
+                .withMessage(partialTextMessage.getMessage())
+                .withUniqueID(partialTextMessage.getUniqueID())
+                .withRoomID(partialTextMessage.getRoomID())
+                .build();
 
         if (!ChatEndpoint.rooms
-                .get(partialTextMessage.getRoomID())
-                .contains(partialTextMessage.getUniqueID())) {
+            .get(partialTextMessage.getRoomID())
+            .contains(partialTextMessage.getUniqueID())) {
             // User that sent the message is not in the room
             return;
         }
@@ -204,10 +205,10 @@ public class ChatEndpoint extends WebSocketAdapter {
                 continue;
             }
             SocketMessage socketMessage =
-                    SocketMessage.Builder.newInstance()
-                            .withMsgType(Msg.MessageEnum.TEXT)
-                            .withPayload(textMessage)
-                            .build();
+                SocketMessage.Builder.newInstance()
+                    .withMsgType(Msg.MessageEnum.TEXT)
+                    .withPayload(textMessage)
+                    .build();
 
             ChatEndpoint.sockets.get(socketID).sendClient(ChatUtils.stringify(socketMessage));
         }
@@ -223,16 +224,16 @@ public class ChatEndpoint extends WebSocketAdapter {
             studentInfo.setThemes(partialInfo.getThemes());
             ChatEndpoint.waitingRooms.replace(this.id, studentInfo);
             ChatEndpoint.sockets
-                    .get(this.id)
-                    .sendClient(
-                            ChatUtils.stringify(
-                                    SocketMessage.Builder.newInstance()
-                                            .withMsgType(Msg.MessageEnum.UPDATE_QUEUE)
-                                            .withPayload(
-                                                    new StudentInfoMessage.Builder()
-                                                            .withStudentInfo(studentInfo)
-                                                            .build())
-                                            .build()));
+                .get(this.id)
+                .sendClient(
+                    ChatUtils.stringify(
+                        SocketMessage.Builder.newInstance()
+                            .withMsgType(Msg.MessageEnum.UPDATE_QUEUE)
+                            .withPayload(
+                                new StudentInfoMessage.Builder()
+                                    .withStudentInfo(studentInfo)
+                                    .build())
+                            .build()));
             LOG.info("Student info updated");
             LOG.info(this.id);
         } catch (Error e) {
@@ -253,21 +254,23 @@ public class ChatEndpoint extends WebSocketAdapter {
         studentInfo.setPositionInQueue(ChatEndpoint.waitingRooms.size() + 1);
 
         StudentInfoMessage infoMessage =
-                new StudentInfoMessage.Builder().withStudentInfo(studentInfo).build();
+            new StudentInfoMessage.Builder().withStudentInfo(studentInfo).build();
 
         if (!ChatEndpoint.waitingRooms.containsKey(this.id)) {
             studentInfo.setTimePlacedInQueue(System.currentTimeMillis());
             ChatEndpoint.waitingRooms.put(this.id, studentInfo);
             SocketMessage confirmation =
-                    SocketMessage.Builder.newInstance()
-                            .withMsgType(Msg.MessageEnum.CONFIRMED_QUEUE)
-                            .withPayload(infoMessage)
-                            .build();
+                SocketMessage.Builder.newInstance()
+                    .withMsgType(Msg.MessageEnum.CONFIRMED_QUEUE)
+                    .withPayload(infoMessage)
+                    .build();
             this.sendClient(ChatUtils.stringify(confirmation));
 
             mixpanelService.trackEventWithStudentInformation(MixpanelEvent.STUDENT_ENTERED_QUEUE, studentInfo);
             LOG.info("New student put in queue, queue length:");
             LOG.info(Integer.toString(ChatEndpoint.waitingRooms.size()));
+
+            sendUpdateQueueMessageToVolunteers();
         }
     }
 
@@ -296,36 +299,36 @@ public class ChatEndpoint extends WebSocketAdapter {
         SocketMessage returnMsg;
 
         if ((studentInfo.getChatType() == Chat.ChatTypeEnum.LEKSEHJELP_VIDEO)
-                || (studentInfo.getChatType() == Chat.ChatTypeEnum.MESTRING_VIDEO)) {
+            || (studentInfo.getChatType() == Chat.ChatTypeEnum.MESTRING_VIDEO)) {
             // With talkyID
             String talkyID = generateID();
             returnMsg =
-                    SocketMessage.Builder.newInstance()
-                            .withMsgType(Msg.MessageEnum.DISTRIBUTE_ROOM)
-                            .withPayload(
-                                    new RoomMessage.Builder()
-                                            .withUniqueID(payload.getUniqueID())
-                                            .withRoomID(roomID)
-                                            .withStudentID(studentID)
-                                            .withTalkyID(talkyID)
-                                            .withVolName(payload.getVolName())
-                                            .build())
-                            .build();
+                SocketMessage.Builder.newInstance()
+                    .withMsgType(Msg.MessageEnum.DISTRIBUTE_ROOM)
+                    .withPayload(
+                        new RoomMessage.Builder()
+                            .withUniqueID(payload.getUniqueID())
+                            .withRoomID(roomID)
+                            .withStudentID(studentID)
+                            .withTalkyID(talkyID)
+                            .withVolName(payload.getVolName())
+                            .build())
+                    .build();
             LOG.info("Video Chat created, id:");
             LOG.info(talkyID);
         } else {
             // without talkyID
             returnMsg =
-                    SocketMessage.Builder.newInstance()
-                            .withMsgType(Msg.MessageEnum.DISTRIBUTE_ROOM)
-                            .withPayload(
-                                    new RoomMessage.Builder()
-                                            .withUniqueID(payload.getUniqueID())
-                                            .withRoomID(roomID)
-                                            .withStudentID(studentID)
-                                            .withVolName(payload.getVolName())
-                                            .build())
-                            .build();
+                SocketMessage.Builder.newInstance()
+                    .withMsgType(Msg.MessageEnum.DISTRIBUTE_ROOM)
+                    .withPayload(
+                        new RoomMessage.Builder()
+                            .withUniqueID(payload.getUniqueID())
+                            .withRoomID(roomID)
+                            .withStudentID(studentID)
+                            .withVolName(payload.getVolName())
+                            .build())
+                    .build();
         }
 
         mixpanelService.trackEventWithStudentInformation(MixpanelEvent.VOLUNTEER_STARTED_HELP, studentInfo);
@@ -375,18 +378,19 @@ public class ChatEndpoint extends WebSocketAdapter {
         activeVolunteers.put(this.id, sender);
 
         SocketMessage returnMsg =
-                SocketMessage.Builder.newInstance()
-                        .withMsgType(Msg.MessageEnum.JOIN_CHAT)
-                        .withPayload(
-                                new RoomMessage.Builder()
-                                        .withUniqueID(payload.getUniqueID())
-                                        .withRoomID(roomID)
-                                        .withUniqueID(payload.getUniqueID())
-                                        .withTalkyID(talkyID)
-                                        .withStudentInfo(payload.getStudentInfo())
-                                        .withChatHistory(payload.getChatHistory())
-                                        .build())
-                        .build();
+            SocketMessage.Builder.newInstance()
+                .withMsgType(Msg.MessageEnum.JOIN_CHAT)
+                .withPayload(
+                    new RoomMessage.Builder()
+                        .withUniqueID(payload.getUniqueID())
+                        .withRoomID(roomID)
+                        .withUniqueID(payload.getUniqueID())
+                        .withTalkyID(talkyID)
+                        .withStudentInfo(payload.getStudentInfo())
+                        .withChatHistory(payload.getChatHistory())
+                        .withVolunteerCount(payload.getVolunteerCount())
+                        .build())
+                .build();
 
         ChatEndpoint.sockets.get(uniqueID).sendClient(ChatUtils.stringify(returnMsg));
         ChatEndpoint.rooms.get(roomID).forEach(uid -> {
@@ -421,19 +425,19 @@ public class ChatEndpoint extends WebSocketAdapter {
         StudentInfo studentInfo = payload.getStudentInfo();
 
         SocketMessage confirmation =
-                SocketMessage.Builder.newInstance()
-                        .withMsgType(Msg.MessageEnum.LEAVE_CHAT)
-                        .withPayload(
-                                new LeaveMessage.Builder()
-                                        .withName(payload.getAuthor())
-                                        .withRoomID(roomID)
-                                        .withUniqueID(uniqueID)
-                                        .build())
-                        .build();
+            SocketMessage.Builder.newInstance()
+                .withMsgType(Msg.MessageEnum.LEAVE_CHAT)
+                .withPayload(
+                    new LeaveMessage.Builder()
+                        .withName(payload.getAuthor())
+                        .withRoomID(roomID)
+                        .withUniqueID(uniqueID)
+                        .build())
+                .build();
 
         long chatDuration = TimeUnit.MILLISECONDS.toMinutes(
-            System.currentTimeMillis() - studentsEnteredChat.get(studentInfo.getUniqueID()
-            ));
+            System.currentTimeMillis() - studentsEnteredChat.get(studentInfo.getUniqueID())
+        );
 
         try {
             List<String> room = ChatEndpoint.rooms.get(roomID);
@@ -445,51 +449,51 @@ public class ChatEndpoint extends WebSocketAdapter {
                     found = true;
                     for (String userIDToSendConfirmationMessageTo : room) {
                         ChatEndpoint.sockets
-                                .get(userIDToSendConfirmationMessageTo)
-                                .sendClient(ChatUtils.stringify(confirmation));
+                            .get(userIDToSendConfirmationMessageTo)
+                            .sendClient(ChatUtils.stringify(confirmation));
                     }
                     room.remove(userID);
-                    if (chatDuration > 4) {
-                        mixpanelService.trackEventWithDuration(
-                            MixpanelEvent.VOLUNTEER_FINISHED_HELP,
-                            studentInfo,
-                            chatDuration
-                        );
-                    }
                     LOG.info("User has left the room");
                     LOG.info(uniqueID);
                 }
             }
 
-            studentsEnteredChat.remove(studentInfo.getUniqueID());
-
-            if (room.size() == 1) {
-                // Send message that chat is closed to student
-                SocketMessage chatClosedMessage =
+            if (room.size() <= 1) {
+                if (room.size() == 1) {
+                    // Send message that chat is closed to student
+                    SocketMessage chatClosedMessage =
                         SocketMessage.Builder.newInstance()
-                                .withMsgType(Msg.MessageEnum.CLOSE_CHAT)
-                                .withPayload(
-                                        // Message can be basically empty. We only really want to
-                                        // send the MsgType
-                                        // CLOSE_CHAT
-                                        new LeaveMessage.Builder().build())
-                                .build();
-                ChatEndpoint.sockets
+                            .withMsgType(Msg.MessageEnum.CLOSE_CHAT)
+                            .withPayload(
+                                // Message can be basically empty. We only really want to
+                                // send the MsgType
+                                // CLOSE_CHAT
+                                new LeaveMessage.Builder().build())
+                            .build();
+                    ChatEndpoint.sockets
                         .get(room.get(0))
                         .sendClient(ChatUtils.stringify(chatClosedMessage));
-                rooms.remove(roomID);
-                LOG.info("Room closed, all 'frivillige' has left");
-            } else if (room.size() < 1) {
+                }
+
+                if (chatDuration > 4) {
+                    mixpanelService.trackEventWithDuration(
+                        MixpanelEvent.VOLUNTEER_FINISHED_HELP,
+                        studentInfo,
+                        chatDuration
+                    );
+                }
+
+                studentsEnteredChat.remove(studentInfo.getUniqueID());
                 rooms.remove(roomID);
                 LOG.info("Room closed, all 'frivillige' has left");
             }
         } catch (Error e) {
             // Send pass errorMessage to the user who requested to leave chat
             SocketMessage errorMessage =
-                    SocketMessage.Builder.newInstance()
-                            .withMsgType(Msg.MessageEnum.ERROR_LEAVING_CHAT)
-                            .withPayload(new LeaveMessage.Builder().build())
-                            .build();
+                SocketMessage.Builder.newInstance()
+                    .withMsgType(Msg.MessageEnum.ERROR_LEAVING_CHAT)
+                    .withPayload(new LeaveMessage.Builder().build())
+                    .build();
             this.sendClient(ChatUtils.stringify(errorMessage));
             LOG.error("Error leaving room");
             LOG.error(e.getMessage());
@@ -500,17 +504,17 @@ public class ChatEndpoint extends WebSocketAdapter {
         RoomMessage payload = gson.fromJson(message, RoomMessage.class);
 
         List<Volunteer> volunteerNames =
-                activeVolunteers.values().stream()
-                        .filter(x -> !x.getChatID().equals(this.id))
-                        .filter(x -> x.getRoomID() == null || !x.getRoomID().equals(payload.getRoomID()))
-                        .collect(Collectors.toList());
+            activeVolunteers.values().stream()
+                .filter(x -> !x.getChatID().equals(this.id))
+                .filter(x -> x.getRoomID() == null || !x.getRoomID().equals(payload.getRoomID()))
+                .collect(Collectors.toList());
 
         SocketMessage list =
-                SocketMessage.Builder.newInstance()
-                        .withMsgType(Msg.MessageEnum.AVAILABLE_CHAT)
-                        .withPayload(
-                                new AvailableQueue.Builder().queueMembers(volunteerNames).build())
-                        .build();
+            SocketMessage.Builder.newInstance()
+                .withMsgType(Msg.MessageEnum.AVAILABLE_CHAT)
+                .withPayload(
+                    new AvailableQueue.Builder().queueMembers(volunteerNames).build())
+                .build();
 
         this.sendClient(ChatUtils.stringify(list));
     }
@@ -527,20 +531,16 @@ public class ChatEndpoint extends WebSocketAdapter {
         this.sendClient(String.format("{\"withMessage\": \"error\", \"error\": \"%s\"}", err));
     }
 
-    private void getQueue() {
-
+    private static SocketMessage getQueueMessage() {
         List<StudentInfo> studentInfoList = new ArrayList<>(ChatEndpoint.waitingRooms.values());
 
-        SocketMessage test =
-                SocketMessage.Builder.newInstance()
-                        .withMsgType(Msg.MessageEnum.QUEUE_LIST)
-                        .withPayload(
-                                new QueueListMessage.Builder()
-                                        .queueMembers(studentInfoList)
-                                        .build())
-                        .build();
-
-        this.sendClient(ChatUtils.stringify(test));
+        return SocketMessage.Builder.newInstance()
+                .withMsgType(Msg.MessageEnum.QUEUE_LIST)
+                .withPayload(
+                    new QueueListMessage.Builder()
+                        .queueMembers(studentInfoList)
+                        .build())
+                .build();
     }
 
     private void reconnectHandler(String msg) {
@@ -554,8 +554,8 @@ public class ChatEndpoint extends WebSocketAdapter {
             ChatEndpoint.sockets.get(uniqueID));
 
         reconnectedUser.ifPresentOrElse(user ->
-            ChatEndpoint.sockets.replace(uniqueID, this)
-        , () -> ChatEndpoint.sockets.put(uniqueID, this));
+                ChatEndpoint.sockets.replace(uniqueID, this)
+            , () -> ChatEndpoint.sockets.put(uniqueID, this));
 
 
         ClosedChat userFromReconnectedList = reconnectList.remove(uniqueID);
@@ -572,34 +572,39 @@ public class ChatEndpoint extends WebSocketAdapter {
         }
 
         ReconnectMessage payload =
-                new ReconnectMessage.Builder().withUniqueID(this.id).withRoomIDs(roomIDs).build();
+            new ReconnectMessage.Builder().withUniqueID(this.id).withRoomIDs(roomIDs).build();
         SocketMessage socketMessage =
-                SocketMessage.Builder.newInstance()
-                        .withMsgType(Msg.MessageEnum.RECONNECT)
-                        .withPayload(payload)
-                        .build();
+            SocketMessage.Builder.newInstance()
+                .withMsgType(Msg.MessageEnum.RECONNECT)
+                .withPayload(payload)
+                .build();
         this.sendClient(ChatUtils.stringify(socketMessage));
         LOG.info("Client reconnected");
         LOG.info(uniqueID);
     }
 
-    static void dispatchLeaveMessage(String message, List<String> room, String roomID) {
+    static void dispatchLeaveMessage(String message, String roomID, boolean isStudent) {
+        List<String> room = ChatEndpoint.rooms.get(roomID);
         room.forEach(
-                uid -> {
-                    ChatEndpoint.sockets
-                            .get(uid)
-                            .sendClient(
-                                    ChatUtils.stringify(
-                                            SocketMessage.Builder.newInstance()
-                                                    .withMsgType(Msg.MessageEnum.LEAVE_CHAT)
-                                                    .withPayload(
-                                                            new TextMessage.Builder()
-                                                                    .withUniqueID("NOTIFICATION")
-                                                                    .withMessage(message)
-                                                                    .withRoomID(roomID)
-                                                                    .build())
-                                                    .build()));
-                });
+            uid -> ChatEndpoint.sockets.get(uid).sendClient(
+                ChatUtils.stringify(
+                    SocketMessage.Builder.newInstance()
+                        .withMsgType(Msg.MessageEnum.LEAVE_CHAT)
+                        .withPayload(
+                            new TextMessage.Builder()
+                                .withUniqueID("NOTIFICATION")
+                                .withMessage(message)
+                                .withRoomID(roomID)
+                                .withVolunteerCount(isStudent ? room.size() : room.size() - 1)
+                                .build())
+                        .build()))
+        );
+    }
+
+    public static void sendUpdateQueueMessageToVolunteers() {
+        ChatEndpoint.activeVolunteers.keySet().forEach(key -> ChatEndpoint.sockets.get(key).sendClient(
+            ChatUtils.stringify(getQueueMessage())
+        ));
     }
 
     //TODO: Sandra, del opp i to funksjoner
@@ -625,13 +630,18 @@ public class ChatEndpoint extends WebSocketAdapter {
                     leftRoom = true;
                     ChatEndpoint.rooms.get(room.getKey()).remove(leaveMessage.getUniqueID());
                     ChatEndpoint.dispatchLeaveMessage(
-                        "Student har forlatt rommet", ChatEndpoint.rooms.get(room.getKey()), room.getKey());
+                        "Student har forlatt rommet",
+                        room.getKey(),
+                        true
+                    );
                 }
                 if (!leftRoom) {
                     ChatEndpoint.updatePositionsInQueue();//TODO: Sandra, burde denne kalles før vi fjerner elev fra waitingRoom?
                     mixpanelService.trackEventWithStudentInformation(MixpanelEvent.STUDENT_LEFT_QUEUE, studentInfo);
                 }
             }
+
+            sendUpdateQueueMessageToVolunteers();
         } catch (NullPointerException e) {
             e.printStackTrace();
         }

--- a/src/main/java/no/capraconsulting/chat/ChatServlet.java
+++ b/src/main/java/no/capraconsulting/chat/ChatServlet.java
@@ -12,6 +12,7 @@ public class ChatServlet extends WebSocketServlet {
     public void configure(WebSocketServletFactory factory)
     {
         factory.getPolicy().setIdleTimeout(TIMEOUT_LIMIT);
+        factory.getExtensionFactory().unregister("permessage-deflate");
         factory.register(ChatEndpoint.class);
         RemoveEndedChats gc = new RemoveEndedChats();
         LOG.info("Started garbage collector");

--- a/src/main/java/no/capraconsulting/chat/RemoveEndedChats.java
+++ b/src/main/java/no/capraconsulting/chat/RemoveEndedChats.java
@@ -50,14 +50,12 @@ public class RemoveEndedChats extends Thread {
                                 if (first.isVolunteer()) {
                                     ChatEndpoint.dispatchLeaveMessage(
                                         String.format("%s har forlatt Chatten", first.getVolunteer().getName()),
-                                        room.getKey(),
-                                        false
+                                        room.getKey()
                                     );
                                 } else {
                                     ChatEndpoint.dispatchLeaveMessage(
                                         "Student har forlatt Chatten",
-                                        room.getKey(),
-                                        true
+                                        room.getKey()
                                     );
                                 }
                             }

--- a/src/main/java/no/capraconsulting/chat/RemoveEndedChats.java
+++ b/src/main/java/no/capraconsulting/chat/RemoveEndedChats.java
@@ -22,46 +22,51 @@ public class RemoveEndedChats extends Thread {
         timer = new Timer();
 
         timer.scheduleAtFixedRate(
-                new TimerTask() {
-                    public void run() {
-                        for (Iterator<ClosedChat> it =
-                                        ChatEndpoint.reconnectList.values().iterator();
-                                it.hasNext(); ) {
-                            ClosedChat first = it.next();
-                            if (first.isTimesUp()) {
-                                ChatEndpoint.reconnectList.values().remove(first);
+            new TimerTask() {
+                public void run() {
+                    for (Iterator<ClosedChat> it =
+                         ChatEndpoint.reconnectList.values().iterator();
+                         it.hasNext(); ) {
+                        ClosedChat first = it.next();
+                        if (first.isTimesUp()) {
+                            ChatEndpoint.reconnectList.values().remove(first);
 
-                                StudentInfo removedFromWaitingRoom =
-                                        ChatEndpoint.waitingRooms.remove(first.getChat().getId());
-                                if (removedFromWaitingRoom != null) {
-                                    ChatEndpoint.updatePositionsInQueue();
-                                }
-
-                                for (ConcurrentMap.Entry<String, List<String>> room :
-                                        ChatEndpoint.rooms.entrySet()) {
-                                    if (!room.getValue().contains(first.getChat().getId())) {
-                                        continue;
-                                    }
-                                    ChatEndpoint.rooms
-                                            .get(room.getKey())
-                                            .remove(first.getChat().getId());
-                                    if (first.isVolunteer()) {
-                                        ChatEndpoint.dispatchLeaveMessage(
-                                                String.format(
-                                                        "%s har forlatt Chatten",
-                                                        first.getVolunteer().getName()),
-                                                room.getValue(), room.getKey());
-                                    } else {
-                                        ChatEndpoint.dispatchLeaveMessage(
-                                                "Student har forlatt Chatten", room.getValue(), room.getKey());
-                                    }
-                                }
-                                LOG.info("Fjernet fra liste");
+                            StudentInfo removedFromWaitingRoom =
+                                ChatEndpoint.waitingRooms.remove(first.getChat().getId());
+                            if (removedFromWaitingRoom != null) {
+                                ChatEndpoint.updatePositionsInQueue();
                             }
+
+                            for (ConcurrentMap.Entry<String, List<String>> room :
+                                ChatEndpoint.rooms.entrySet()) {
+                                if (!room.getValue().contains(first.getChat().getId())) {
+                                    continue;
+                                }
+                                ChatEndpoint.rooms
+                                    .get(room.getKey())
+                                    .remove(first.getChat().getId());
+                                if (first.isVolunteer()) {
+                                    ChatEndpoint.dispatchLeaveMessage(
+                                        String.format("%s har forlatt Chatten", first.getVolunteer().getName()),
+                                        room.getKey(),
+                                        false
+                                    );
+                                } else {
+                                    ChatEndpoint.dispatchLeaveMessage(
+                                        "Student har forlatt Chatten",
+                                        room.getKey(),
+                                        true
+                                    );
+                                }
+                            }
+                            LOG.info("Fjernet fra liste");
                         }
                     }
-                },
-                delay,
-                period);
+
+                    ChatEndpoint.sendUpdateQueueMessageToVolunteers();
+                }
+            },
+            delay,
+            period);
     }
 }

--- a/src/main/java/no/capraconsulting/chat/RemoveEndedChats.java
+++ b/src/main/java/no/capraconsulting/chat/RemoveEndedChats.java
@@ -24,6 +24,7 @@ public class RemoveEndedChats extends Thread {
         timer.scheduleAtFixedRate(
             new TimerTask() {
                 public void run() {
+                    boolean queueUpdated = false;
                     for (Iterator<ClosedChat> it =
                          ChatEndpoint.reconnectList.values().iterator();
                          it.hasNext(); ) {
@@ -35,6 +36,7 @@ public class RemoveEndedChats extends Thread {
                                 ChatEndpoint.waitingRooms.remove(first.getChat().getId());
                             if (removedFromWaitingRoom != null) {
                                 ChatEndpoint.updatePositionsInQueue();
+                                queueUpdated = true;
                             }
 
                             for (ConcurrentMap.Entry<String, List<String>> room :
@@ -63,7 +65,9 @@ public class RemoveEndedChats extends Thread {
                         }
                     }
 
-                    ChatEndpoint.sendUpdateQueueMessageToVolunteers();
+                    if (queueUpdated) {
+                        ChatEndpoint.sendUpdateQueueMessageToVolunteers();
+                    }
                 }
             },
             delay,

--- a/src/main/java/no/capraconsulting/chatmessages/ActiveSubjectsMessage.java
+++ b/src/main/java/no/capraconsulting/chatmessages/ActiveSubjectsMessage.java
@@ -1,17 +1,17 @@
 package no.capraconsulting.chatmessages;
 
-import java.util.List;
+import java.util.Set;
 
 public class ActiveSubjectsMessage extends Message {
-    private List<String> activeSubjects;
+    private Set<String> activeSubjects;
 
-    private List<String> getActiveSubjects() { return this.activeSubjects; }
+    private Set<String> getActiveSubjects() { return this.activeSubjects; }
 
     protected static abstract class Init<T extends Init<T>> extends Message.Init<T> {
 
-        private List<String> activeSubjects;
+        private Set<String> activeSubjects;
 
-        public T activeSubjects(List<String> activeSubjects) {
+        public T activeSubjects(Set<String> activeSubjects) {
             this.activeSubjects = activeSubjects;
             return self();
         }

--- a/src/main/java/no/capraconsulting/chatmessages/ActiveSubjectsMessage.java
+++ b/src/main/java/no/capraconsulting/chatmessages/ActiveSubjectsMessage.java
@@ -1,0 +1,35 @@
+package no.capraconsulting.chatmessages;
+
+import java.util.List;
+
+public class ActiveSubjectsMessage extends Message {
+    private List<String> activeSubjects;
+
+    private List<String> getActiveSubjects() { return this.activeSubjects; }
+
+    protected static abstract class Init<T extends Init<T>> extends Message.Init<T> {
+
+        private List<String> activeSubjects;
+
+        public T activeSubjects(List<String> activeSubjects) {
+            this.activeSubjects = activeSubjects;
+            return self();
+        }
+
+        public ActiveSubjectsMessage build() {
+            return new ActiveSubjectsMessage(this);
+        }
+    }
+
+    public static class Builder extends Init<Builder> {
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+
+    public ActiveSubjectsMessage(Init<?> init) {
+        super(init);
+        this.activeSubjects = init.activeSubjects;
+    }
+}

--- a/src/main/java/no/capraconsulting/chatmessages/LeaveMessage.java
+++ b/src/main/java/no/capraconsulting/chatmessages/LeaveMessage.java
@@ -5,6 +5,7 @@ public class LeaveMessage extends Message {
     protected String name;
     protected String roomID;
     protected String removedBy;
+    private long volunteerCount;
 
     public String getName() {
         return name;
@@ -21,6 +22,7 @@ public class LeaveMessage extends Message {
         private String name;
         private String roomID;
         private String removedBy;
+        private long volunteerCount;
 
         public T withName(String name) {
             this.name = name;
@@ -34,6 +36,11 @@ public class LeaveMessage extends Message {
 
         public T withRemovedBy(String removedBy) {
             this.removedBy = removedBy;
+            return self();
+        }
+
+        public T withVolunteerCount(long volunteerCount) {
+            this.volunteerCount = volunteerCount;
             return self();
         }
 
@@ -54,6 +61,7 @@ public class LeaveMessage extends Message {
         this.name = init.name;
         this.roomID = init.roomID;
         this.removedBy = init.removedBy;
+        this.volunteerCount = init.volunteerCount;
     }
 
 }

--- a/src/main/java/no/capraconsulting/chatmessages/RoomMessage.java
+++ b/src/main/java/no/capraconsulting/chatmessages/RoomMessage.java
@@ -12,7 +12,7 @@ public class RoomMessage extends Message {
     private List<TextMessage> chatHistory;
     private String talkyID;
     protected String author;
-    private Integer volunteerCount;
+    private long volunteerCount;
 
     public String getVolName() {
         return volName;
@@ -41,7 +41,7 @@ public class RoomMessage extends Message {
     public void setAuthor(String author) { this.author = author;}
     public String getAuthor(){ return author; }
 
-    public Integer getVolunteerCount() {
+    public long getVolunteerCount() {
         return volunteerCount;
     }
 
@@ -53,7 +53,7 @@ public class RoomMessage extends Message {
         private String talkyID;
         private StudentInfo studentInfo;
         private List<TextMessage> chatHistory;
-        private Integer volunteerCount;
+        private long volunteerCount;
 
         public T withStudentID(String studentID) {
             this.studentID = studentID;
@@ -85,7 +85,7 @@ public class RoomMessage extends Message {
             return self();
         }
 
-        public T withVolunteerCount(Integer volunteerCount) {
+        public T withVolunteerCount(long volunteerCount) {
             this.volunteerCount = volunteerCount;
             return self();
         }

--- a/src/main/java/no/capraconsulting/chatmessages/RoomMessage.java
+++ b/src/main/java/no/capraconsulting/chatmessages/RoomMessage.java
@@ -12,6 +12,7 @@ public class RoomMessage extends Message {
     private List<TextMessage> chatHistory;
     private String talkyID;
     protected String author;
+    private Integer volunteerCount;
 
     public String getVolName() {
         return volName;
@@ -40,6 +41,10 @@ public class RoomMessage extends Message {
     public void setAuthor(String author) { this.author = author;}
     public String getAuthor(){ return author; }
 
+    public Integer getVolunteerCount() {
+        return volunteerCount;
+    }
+
     protected static abstract class Init<T extends Init<T>> extends Message.Init<T> {
 
         private String studentID;
@@ -48,6 +53,7 @@ public class RoomMessage extends Message {
         private String talkyID;
         private StudentInfo studentInfo;
         private List<TextMessage> chatHistory;
+        private Integer volunteerCount;
 
         public T withStudentID(String studentID) {
             this.studentID = studentID;
@@ -78,6 +84,12 @@ public class RoomMessage extends Message {
             this.chatHistory = chatHistory;
             return self();
         }
+
+        public T withVolunteerCount(Integer volunteerCount) {
+            this.volunteerCount = volunteerCount;
+            return self();
+        }
+
         public RoomMessage build() {
             return new RoomMessage(this);
         }
@@ -98,5 +110,6 @@ public class RoomMessage extends Message {
         this.studentInfo = init.studentInfo;
         this.chatHistory = init.chatHistory;
         this.volName = init.volName;
+        this.volunteerCount = init.volunteerCount;
     }
 }

--- a/src/main/java/no/capraconsulting/chatmessages/TextMessage.java
+++ b/src/main/java/no/capraconsulting/chatmessages/TextMessage.java
@@ -13,6 +13,7 @@ public class TextMessage extends Message{
     private String imgUrl;
     private String author;
     private String roomID;
+    private Integer volunteerCount;
 
     public String getMessage() {
         return message;
@@ -35,6 +36,7 @@ public class TextMessage extends Message{
         private String imgUrl;
         private String author;
         private String roomID;
+        private Integer volunteerCount;
 
         public T withMessage(String message) {
             this.message = message;
@@ -60,6 +62,12 @@ public class TextMessage extends Message{
             this.imgUrl = imgUrl;
             return self();
         }
+
+        public T withVolunteerCount(Integer volunteerCount) {
+            this.volunteerCount = volunteerCount;
+            return self();
+        }
+
         public TextMessage build() {
             return new TextMessage(this);
         }
@@ -79,5 +87,6 @@ public class TextMessage extends Message{
         this.files = init.files;
         this.imgUrl = init.imgUrl;
         this.roomID = init.roomID;
+        this.volunteerCount = init.volunteerCount;
     }
 }

--- a/src/main/java/no/capraconsulting/chatmessages/TextMessage.java
+++ b/src/main/java/no/capraconsulting/chatmessages/TextMessage.java
@@ -13,7 +13,7 @@ public class TextMessage extends Message{
     private String imgUrl;
     private String author;
     private String roomID;
-    private Integer volunteerCount;
+    private long volunteerCount;
 
     public String getMessage() {
         return message;
@@ -24,6 +24,10 @@ public class TextMessage extends Message{
     public String getAuthor() { return author; }
 
     public String getRoomID(){ return roomID; }
+
+    public long getVolunteerCount() {
+        return volunteerCount;
+    }
 
     public ArrayList<File> getFiles() {
         return files;
@@ -36,7 +40,7 @@ public class TextMessage extends Message{
         private String imgUrl;
         private String author;
         private String roomID;
-        private Integer volunteerCount;
+        private long volunteerCount;
 
         public T withMessage(String message) {
             this.message = message;
@@ -63,7 +67,7 @@ public class TextMessage extends Message{
             return self();
         }
 
-        public T withVolunteerCount(Integer volunteerCount) {
+        public T withVolunteerCount(long volunteerCount) {
             this.volunteerCount = volunteerCount;
             return self();
         }

--- a/src/main/java/no/capraconsulting/config/CORSFilter.java
+++ b/src/main/java/no/capraconsulting/config/CORSFilter.java
@@ -11,6 +11,8 @@ import javax.ws.rs.container.ContainerResponseFilter;
  * This filter is optionally enabled and wired in {@link JerseyConfig}
  * See {@link JerseyConfig} for details about properties used to control allowed origin and headers
  */
+
+// TODO: Sandra til prod, sett opp hvilke domener som skal tillates (både frivillig-frontend og student-frontend)
 public class CORSFilter implements ContainerResponseFilter {
     private static final Logger log = LoggerFactory.getLogger(CORSFilter.class);
 

--- a/src/main/java/no/capraconsulting/config/PropertiesHelper.java
+++ b/src/main/java/no/capraconsulting/config/PropertiesHelper.java
@@ -20,6 +20,9 @@ public class PropertiesHelper {
     public static final String AZURE_AUTH_ISSUER = "azure.auth.issuer";
     public static final String AZURE_AUTH_AUDIENCE = "azure.auth.audience";
     public static final String MIXPANEL_PROJECT_TOKEN = "mixpanel.project.token";
+    public static final String MAIL_USERNAME = "mail.username";
+    public static final String MAIL_PASSWORD = "mail.password";
+    public static final String MAIL_APIKEY = "mail.apikey";
 
     public static Properties getProperties() {
         Properties properties = new Properties();

--- a/src/main/java/no/capraconsulting/db/Database.java
+++ b/src/main/java/no/capraconsulting/db/Database.java
@@ -34,12 +34,15 @@ public class Database {
 
         Properties properties = PropertiesHelper.getProperties();
         String name = getProperty(properties, PropertiesHelper.DB_CONTAINER_NAME);
-        String port = getProperty(properties, PropertiesHelper.DB_PORT); 
-        String database = getProperty(properties, PropertiesHelper.DB_NAME); 
+        String port = getProperty(properties, PropertiesHelper.DB_PORT);
+        String database = getProperty(properties, PropertiesHelper.DB_NAME);
         String user = getProperty(properties, PropertiesHelper.DB_USER);
         String password = getProperty(properties, PropertiesHelper.DB_PASSWORD);
 
-        String url = String.format("jdbc:sqlserver://%s:%s;databaseName=%s", name, port, database);        
+        String url = String.format("jdbc:sqlserver://%s:%s;database=%s;user=%s;password=%s;encrypt=true;" +
+                "trustServerCertificate=false;hostNameInCertificate=*.database.windows.net;loginTimeout=30",
+            name, port, database, user, password);
+
         config.setJdbcUrl(url);
         config.setUsername(user);
         config.setPassword(password);

--- a/src/main/java/no/capraconsulting/endpoints/SubjectEndpoint.java
+++ b/src/main/java/no/capraconsulting/endpoints/SubjectEndpoint.java
@@ -1,6 +1,5 @@
 package no.capraconsulting.endpoints;
 
-import no.capraconsulting.chat.ChatEndpoint;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -66,45 +65,6 @@ public final class SubjectEndpoint {
             return Response.status(422).build();
         }
 
-    }
-
-    @GET
-    @Path("active")
-    @Produces({MediaType.APPLICATION_JSON})
-    public Response getActiveSubjects(@QueryParam("isMestring") int isMestring) {
-        String query = "" +
-            "SELECT Volunteer_Subjects.volunteer_id, Volunteer_Subjects.subject_id, Subjects.subject " +
-            "FROM VOLUNTEER_SUBJECTS Volunteer_Subjects " +
-            "JOIN SUBJECTS Subjects ON Volunteer_Subjects.subject_id = Subjects.id " +
-            "WHERE is_mestring = ?";
-
-        try {
-            RowSet result = Database.INSTANCE.selectQuery(query, isMestring);
-            Map<Integer, JSONObject> activeSubjects = new HashMap<Integer, JSONObject>();
-
-            while (result.next()) {
-                int subjectID = result.getInt("subject_id");
-                String volunteerID = result.getString("volunteer_id");
-                String subjectTitle = result.getString("subject");
-                JSONObject subject = activeSubjects.getOrDefault(subjectID, new JSONObject());
-
-                ChatEndpoint.activeVolunteers.entrySet().forEach(entry -> {
-                    if (volunteerID.equals(entry.getValue().getId())) {
-                        subject.put("id", subjectID);
-                        subject.put("subject", subjectTitle);
-                        subject.put("isMestring", isMestring);
-                    }
-                });
-                activeSubjects.put(subjectID, subject);
-            }
-            LOG.info("Active subjects are:");
-            LOG.info(activeSubjects.values().toString());
-
-            return Response.ok(activeSubjects.values().toString()).build();
-        } catch (SQLException e) {
-            LOG.error(e.getMessage());
-            return Response.status(422).build();
-        }
     }
 
     @POST

--- a/src/main/java/no/capraconsulting/enums/Msg.java
+++ b/src/main/java/no/capraconsulting/enums/Msg.java
@@ -21,5 +21,6 @@ public interface Msg {
         SET_VOLUNTEER,
         STUDENT_LEAVE,
         REMOVE_STUDENT_FROM_QUEUE,
+        UPDATE_ACTIVE_SUBJECTS,
     }
 }

--- a/src/main/java/no/capraconsulting/mail/MailService.java
+++ b/src/main/java/no/capraconsulting/mail/MailService.java
@@ -1,5 +1,12 @@
 package no.capraconsulting.mail;
 
+import com.sendgrid.Method;
+import com.sendgrid.Request;
+import com.sendgrid.SendGrid;
+import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
+import no.capraconsulting.config.PropertiesHelper;
 import org.apache.commons.mail.DefaultAuthenticator;
 import org.apache.commons.mail.HtmlEmail;
 import org.slf4j.Logger;
@@ -11,11 +18,11 @@ import java.util.concurrent.*;
 public class MailService implements Callable<Response>{
 
     private static Logger LOG = LoggerFactory.getLogger(MailService.class);
-    private static final String HOST = "smtp.gmail.com";
+    private static final String HOST = "smtp.sendgrid.net";
     private static final int PORT = 587;
     private static final boolean SSL_FLAG = true;
-    private static final String ADDRESS = "";
-    private static final String PASSWORD = "";
+    private static final String ADDRESS = PropertiesHelper.getStringProperty(PropertiesHelper.getProperties(), PropertiesHelper.MAIL_USERNAME, null);
+    private static final String PASSWORD = PropertiesHelper.getStringProperty(PropertiesHelper.getProperties(), PropertiesHelper.MAIL_PASSWORD, null);
 
     private String userEmail;
     private String topic;
@@ -31,16 +38,29 @@ public class MailService implements Callable<Response>{
     public Response call() {
         String userName = ADDRESS;
         String password = PASSWORD;
+        String apiKey = PropertiesHelper.getStringProperty(PropertiesHelper.getProperties(), PropertiesHelper.MAIL_APIKEY, null);
 
         String fromAddress= "no-reply@rodekors.no";
 
         //We get these values from the database
-        String toAddress =  userEmail;    //questionDTO.getEmail();
+        Email toAddress = new Email(userEmail);    //questionDTO.getEmail();
         String subject = topic;               // questionDTO.getTopic();
         String message = answer;  // questionDTO.getAnswer(); + question(?)
 
         try {
-            HtmlEmail email = new HtmlEmail();
+            Email email = new Email(ADDRESS, fromAddress);
+            Content content = new Content("text/html", message);
+            Mail mail = new Mail(email, subject, toAddress, content);
+            SendGrid sg = new SendGrid(apiKey);
+            Request request = new Request();
+
+            request.setMethod(Method.POST);
+            request.setEndpoint("mail/send");
+            request.setBody(mail.build());
+            sg.api(request);
+
+            return Response.ok("Mail successfully sent!").build();
+            /*HtmlEmail email = new HtmlEmail();
             email.setHostName(HOST);
             email.setSmtpPort(PORT);
             email.setAuthenticator(new DefaultAuthenticator(userName, password));
@@ -51,7 +71,7 @@ public class MailService implements Callable<Response>{
             email.setTextMsg("Your email client does not support HTML");
             email.addTo(toAddress);
             email.send();
-            return Response.ok("Mail successfully sent!").build();
+            return Response.ok("Mail successfully sent!").build();*/
         }catch(Exception ex){
             LOG.error("Unable to send mail");
             LOG.error(ex.getMessage());

--- a/src/main/java/no/capraconsulting/mail/MailService.java
+++ b/src/main/java/no/capraconsulting/mail/MailService.java
@@ -60,18 +60,6 @@ public class MailService implements Callable<Response>{
             sg.api(request);
 
             return Response.ok("Mail successfully sent!").build();
-            /*HtmlEmail email = new HtmlEmail();
-            email.setHostName(HOST);
-            email.setSmtpPort(PORT);
-            email.setAuthenticator(new DefaultAuthenticator(userName, password));
-            email.setSSLOnConnect(SSL_FLAG);
-            email.setFrom(userName, fromAddress);
-            email.setSubject(subject);
-            email.setHtmlMsg(message);
-            email.setTextMsg("Your email client does not support HTML");
-            email.addTo(toAddress);
-            email.send();
-            return Response.ok("Mail successfully sent!").build();*/
         }catch(Exception ex){
             LOG.error("Unable to send mail");
             LOG.error(ex.getMessage());


### PR DESCRIPTION
**For prod**
- Update AppMain: create chatServlet and add it to contextHandler, so WS can be sent on /ws on the same port (8080). Do not have to expose 3002 anymore.
- Update connection string
- Update exposed ports
- Update MailService to use SendGrid from Azure instead of Gmail

**Active subjects**
- Add new message, ActiveSubjectsMessage
- Send the active subjects in a socket message to students, so they can know which subjects are available at all times. 
- Create a helper method in EndpointUtils which retrieves all subjects that the active volunteers have. 

**Count volunteers in chat**
- Create method to sum total number of volunteers in a chat room, and add this number to web sockets messages sent went volunteers enter and leave the chat.

**Small fixes**
- Ensure that the queue actually is updated in RemoveEndedChats before sending update queue message, or else the message will be sent more often than necessary.